### PR TITLE
Update permissions checks in default_permissions_on_risky_events

### DIFF
--- a/opa/rego/rules/default_permissions_on_risky_events.rego
+++ b/opa/rego/rules/default_permissions_on_risky_events.rego
@@ -26,24 +26,11 @@ results contains poutine.finding(rule, pkg.purl, {
 }) if {
 	pkg := input.packages[_]
 	workflow = pkg.github_actions_workflows[_]
-	job := workflow.jobs[_]
 
 	utils.filter_workflow_events(workflow, github.events)
 
-	utils.empty(workflow.permissions)
-	utils.empty(job.permissions)
-}
-
-results contains poutine.finding(rule, pkg.purl, {
-	"path": workflow.path,
-	"event_triggers": [event | event := workflow.events[j].name],
-}) if {
-	pkg := input.packages[_]
-	workflow = pkg.github_actions_workflows[_]
+	workflow.permissions == null
+  
 	job := workflow.jobs[_]
-
-	utils.filter_workflow_events(workflow, github.events)
-
-	not workflow.permissions
-	not job.permissions
+	job.permissions == null
 }


### PR DESCRIPTION
The rule had errors when setting a empty permissions at the workflow level and null job.

This shouldn't hit.

```yaml
name: pull_request_target
on:
  pull_request_target:
    
permissions: {}

jobs:
  one:
    runs-on: ubuntu-22.04
    steps:
      - name: Dump GitHub context
        env:
          GITHUB_CONTEXT: ${{ toJson(github) }}
        run: echo "$GITHUB_CONTEXT"
```